### PR TITLE
fix: poster Image 없을때 대체이미지 적용

### DIFF
--- a/src/pages/movieList/components/Movie.jsx
+++ b/src/pages/movieList/components/Movie.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
+import ImageCard from '../../../components/ImageCard';
 import StarRate from '../../../components/StarRate';
 
 function Movie({ movie, rank }) {
@@ -9,7 +10,11 @@ function Movie({ movie, rank }) {
     <Container to={`/movie/${movie.id}`}>
       <ThumbItem>
         <ImageWrapper>
-          <img src={process.env.REACT_APP_IMAGE_URL + movie.poster_path} />
+          <ImageCard
+            src={process.env.REACT_APP_IMAGE_URL + movie.poster_path}
+            alt={movie.id}
+            width={204}
+          ></ImageCard>
         </ImageWrapper>
         <BackInfoWrapper>
           <p>{movie.overview}</p>


### PR DESCRIPTION

## 📑 제목

 poster Image 없을때 대체이미지 적용

## ✔️ 셀프 체크리스트

- [ ] Warning Message가 발생하지 않았나요?
- [ ] Coding Convention을 준수했나요?
- [ ] Git Flow를 준수했나요?

## 💬 작업 내용

movie Page에서 poster Image 가 없을때 
img의 handleOnErrorImage를 통해 img의 src를 대체 이미지 src 로 변경

## 🚧 PR 특이 사항

- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- 혹은 급하게 PR을 merge해야하는 사유를 적어주세요. 후행 작업 issue number나 백로그도 남겨주시면 좋습니다.
